### PR TITLE
Add "Attacks Grouped by CIDR Block" section

### DIFF
--- a/code-examples/attacked-cidrs.py
+++ b/code-examples/attacked-cidrs.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+""" Report on number of attacks by CIDR block
+
+This program has some constants defined at the bottom of it that set the SP
+Leader, the SP REST API Token for that leader, the path to the SSL certificate
+file, the start and end times for finding alerts, and the netmask lengths for
+IPv4 networks and IPv6 networks.
+
+It then pages through the SP REST API's /alerts/ endpoint and collects
+addresses from the alert information.  Those addresses are then collected in to
+CIDR blocks and a simple table is printed.
+
+"""
+
+from __future__ import print_function
+import ipaddress
+import requests
+import sys
+from datetime import datetime
+
+
+def iso8601_to_datetime(iso8601_string):
+    """annoyingly, Python can produce but not read ISO8601 datestamps
+
+    this function does some pretty dumb things to convert that format
+    back into a Python datetime object
+    """
+    return datetime.strptime(
+        iso8601_string.split('+')[0],
+        '%Y-%m-%dT%H:%M:%S')
+
+
+def get_attacked_addresses(leader, token, cert,
+                           start, end,
+                           page=1, addrs=[]):
+    """Get the `host_address` field from alerts between start and end
+
+    Page through the `/alerts/` endpoint and gather up the
+    `host_address` addresses into a list, this function calls itself
+    until the last alert in the list started before the `start` time
+    """
+
+    url = 'https://{}/api/sp/v2/alerts/?page={}'.format(leader, page)
+    start_dt = iso8601_to_datetime(start)
+    end_dt = iso8601_to_datetime(end)
+
+    r = requests.get(url,
+                     headers={
+                         "X-Arbux-APIToken": token,
+                         "Content-Type": 'application/vnd.json+api'
+                         },
+                     verify=cert)
+
+    if r.status_code is not requests.codes.ok:
+        print("API request for alerts returned {} ({})".format(
+            r.reason, r.status_code), file=sys.stderr)
+        return None
+
+    alerts = r.json()
+
+    for alert in alerts['data']:
+        if 'attributes' in alert and 'subobject' in alert['attributes']:
+            if 'host_address' in alert['attributes']['subobject']:
+                alert_time = iso8601_to_datetime(
+                    alerts['data'][-1]['attributes']['start_time']
+                    )
+                if alert_time > start_dt and alert_time < end_dt:
+                    addrs.append(
+                        alert['attributes']['subobject']['host_address']
+                        )
+
+    last_alert = iso8601_to_datetime(
+        alerts['data'][-1]['attributes']['start_time'])
+    if last_alert > start_dt:
+        print ("paging to page {}; # addresses so far: {}".format(
+            page+1, len(addrs)))
+        get_attacked_addresses(leader, token, cert, start,
+                               end, page+1, addrs)
+
+    return addrs
+
+
+def bundle_addresses(addrs, netmasks):
+    """Use the ipaddress library to put addresses into CIDR blocks
+
+    coerce the address into a CIDR block with the correct netmask for
+    its IP version (4 or 6), and then put that CIDR into a dictionary
+    where occurances are counted.  See
+    https://github.com/phihag/ipaddress and/or `pip install ipaddress`
+    """
+    networks = {}
+    for addr in addrs:
+        addr = ipaddress.ip_address(addr)
+        network = str(addr)+"/"+netmasks[str(addr.version)]
+        network = ipaddress.ip_network(network, strict=False)
+        if str(network) in networks:
+            networks[str(network)] += 1
+        else:
+            networks[str(network)] = 1
+
+    return networks
+
+
+if __name__ == '__main__':
+    SPLEADER = 'spleader.example.com'
+    APITOKEN = 'MySecretAPItoken'
+    CERTFILE = './certfile'
+
+    START_DATE = '2018-05-23T12:00:00+00:00'
+    END_DATE = '2018-05-23T23:00:00+00:00'
+
+    IPv4_MASK = '24'
+    IPv6_MASK = '116'
+
+    addresses = get_attacked_addresses(SPLEADER,
+                                       APITOKEN,
+                                       CERTFILE,
+                                       START_DATE,
+                                       END_DATE)
+    print ("# addresses found between {} and {}: {}".format(
+        START_DATE,
+        END_DATE,
+        len(addresses)))
+
+    cidrs = bundle_addresses(addresses, {'4': IPv4_MASK,
+                                         '6': IPv6_MASK})
+
+    print("{:>25}-+-{}".format("-"*25, "---------"))
+    print("{:>25} | {}".format("Subnet", "# Attacks"))
+    print("{:>25}-+-{}".format("-"*25, "---------"))
+    for cidr in sorted(cidrs):
+        print("{:>25} | {:>8}".format(cidr, cidrs[cidr]))

--- a/sp-rest-api-tutorial.txt
+++ b/sp-rest-api-tutorial.txt
@@ -1491,6 +1491,53 @@ listings package.
 
    #+INCLUDE: code-examples/radarplots.py src python
 
+** Example: Attacks Grouped by CIDR Block
+   #+INDEX: /alerts/ endpoint
+   #+INDEX: cidrs
+   #+INDEX: python!ipaddress
+   #+INDEX: paging!recursion
+
+   Arbor Networks SP accumulates and stores a lot of data about
+   network traffic and distributed denial of service (DDoS) attacks
+   and presents this data in ways that have proven useful to network
+   engineers and network security analysts.  That data can be used in
+   many other ways by extracting it via the REST API and applying
+   information specific to your needs.
+
+   This example simply takes IP addresses from the alert data,
+   aggregates them into CIDR blocks of a configurable size, and prints
+   a simple report.  It uses the =ipaddress=[fn:9] Python library and
+   is written for Python2; =ipaddress= is included with Python3, so
+   this program is easily adapted for Python3.
+
+   When run, this program recursively calls its function
+   =get_attacked_addresses= to step through the pages of data from the
+   =/alerts/= endpoint until the last item in the list of alerts on
+   the current page is outside of the specified date rang, then puts
+   those addresses into IPv4 or IPv6 CIDR blocks and counts them,
+   finally printing a simple report.  All of that looks like this:
+   #+BEGIN_EXAMPLE
+     paging to page 2; # addresses so far: 0
+     paging to page 3; # addresses so far: 35
+     paging to page 4; # addresses so far: 72
+     paging to page 5; # addresses so far: 100
+     paging to page 6; # addresses so far: 108
+     paging to page 7; # addresses so far: 126
+     # addresses found between 2018-05-23T12:00:00+00:00 and 2018-05-23T23:00:00+00:00: 126
+     --------------------------+----------
+                        Subnet | # Attacks
+     --------------------------+----------
+                 10.100.2.0/24 |        1
+                 149.39.0.0/24 |        6
+                149.81.12.0/24 |       11
+                151.107.2.0/24 |        5
+              216.175.102.0/24 |       18
+            3ffe:1:14:20::/116 |       60
+               70.107.137.0/24 |       10
+                85.94.160.0/24 |       15
+   #+END_EXAMPLE
+
+   #+INCLUDE: code-examples/attacked-cidrs.py src python
 
 * Configuration
 
@@ -2346,3 +2393,5 @@ the burden of updating all of the examples and descriptions every time
 a new version of SP is released.  So if you come across an example
 that is 8 versions old, be cautious or edit it and submit an update to
 this document.
+
+[fn:9] https://github.com/phihag/ipaddress


### PR DESCRIPTION

[sp-rest-api-tutorial-cidr-grouping-changes.pdf](https://github.com/arbor/sp-rest-api-cookbook/files/2036260/sp-rest-api-tutorial-cidr-grouping-changes.pdf)

This came from a question from C F Chui on the deployment email list about
grouping attacked IP addresses into CIDR blocks.

The Python program shows the number of alerts grouped by CIDR in timerange

This takes some hard-coded parameters for netmask length and start and end
dates and pages through the `/alerts/` endpoint to gather up addresses that are
then grouped together in CIDRs with the configured netmask length and a report
on the number of attacks per CIDR is printed