### PR TITLE
Added Docker config to render text file to PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,59 @@ and pull requests**
 
 ## Rendering
 
-If you want to render this you can use Emacs+Orgmode's Export (`C-e`)
-command to produce HTML, PDF, etc.
+_The tools described here to render the text file to a PDF file are
+probably pretty fragile, so please feel free to open [issues in
+GitHub](https://github.com/arbor/sp-rest-api-cookbook/issues) or make
+pull requests to make this more robust._
+
+In the same directory as this README file is a Bash shell script
+called `mkpdf.sh` that will create a Docker image for you, or use an
+existing Docker image that will then convert the Emacs org-mode file
+(hardcoded in this case to be the file `sp-rest-api-tutorial.txt`) to
+a LaTeX file than is then rendered to PDF.
+
+What this is really doing is using the Docker file and two supporting
+files in the `render` directory to create a Docker image that contains
+everything you need to render `sp-rest-api-cookbook.txt` to a PDF
+file.
+
+Once you have [Docker](http://docker.com) installed, you should be
+able to build a Docker image (which, until you delete it, is a
+one-time operation) by typing (in the `sp-rest-api-cookbook`
+directory):
+
+    docker build -t cookbook-render render
+
+This might take a while and will require a network connection.  Once
+it is done, you can see it in the list of Docker images you have by
+typing:
+
+    docker images
+
+Once you have an image called `cookbook-render` you can type:
+
+    docker run -v `pwd`:/source --rm cookbook-render sp-rest-api-cookbook.txt
+
+If all goes well, this will produce a file called
+`sp-rest-api-cookbook.pdf`.  To render `sp-rest-api-cookbook.txt` into
+a PDF file again, you do not need to do the `docker build` step, just
+the `docker run` step, and you don't need a network connection for
+that.
+
+Alternatively, if you want to use Emacs to render this you can use
+Emacs+Orgmode's Export (`C-e`) command to produce HTML, PDF, etc.
 
 Exporting from Emacs Orgmode as a LaTeX file is the easiest thing to
 do, then, assuming you have the LaTeX packages that are required, you
 can run the commands:
 
-   pdflatex -shell-escape sp-rest-api-tutorial
-   pdflatex -shell-escape sp-rest-api-tutorial
-   makeindex sp-rest-api-tutorial
-   pdflatex -shell-escape sp-rest-api-tutorial
+    pdflatex -shell-escape sp-rest-api-tutorial
+    pdflatex -shell-escape sp-rest-api-tutorial
+    makeindex sp-rest-api-tutorial
+    pdflatex -shell-escape sp-rest-api-tutorial
 
 to produce a PDF file.
+
 
 ## Releases
 

--- a/mkpdf.sh
+++ b/mkpdf.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+DOCKER_CMD='docker'
+DOCKER_DIR='./render'
+DOCKER_IMAGE_NAME='cookbook-render'
+INPUT_FILE='sp-rest-api-tutorial.txt'
+
+IS_IMAGE=`$DOCKER_CMD images | grep $DOCKER_IMAGE_NAME | wc -l`
+
+if [ $IS_IMAGE -gt 0 ] ; then
+    echo "Using existing image ($DOCKER_IMAGE_NAME)"
+else
+    echo "Building new docker image, this will take a bit"
+    if [ ! -d $DOCKER_DIR ] ; then
+        echo "Can't find the directory $DOCKER_DIR so can't proceed"
+        exit 1
+    fi
+    $DOCKER_CMD build -t $DOCKER_IMAGE_NAME $DOCKER_DIR > /dev/null 2>&1
+fi
+
+if [ ! -f $INPUT_FILE ] ; then
+    echo "Can't find $INPUT_FILE; make sure you are in the correct directory"
+    exit 1
+fi
+
+$DOCKER_CMD run -v `pwd`:/source --rm $DOCKER_IMAGE_NAME $INPUT_FILE

--- a/render/Dockerfile
+++ b/render/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu
+RUN apt-get update
+RUN apt-get install -y tzdata
+RUN apt-get install -y emacs
+RUN apt-get install -y texlive
+RUN apt-get install -y texlive-pictures
+RUN apt-get install -y texlive-latex-extra
+RUN apt-get install -y python-pygments
+COPY export.el /
+COPY render.sh /
+ENTRYPOINT ["/bin/bash", "render.sh"]

--- a/render/export.el
+++ b/render/export.el
@@ -1,0 +1,30 @@
+(setq kill-buffer-query-functions
+  (remove 'process-kill-buffer-query-function
+   kill-buffer-query-functions))
+
+(require 'org)
+(require 'ox-latex)
+(add-to-list 'org-latex-classes
+	     '("tufte-book"
+	       "\\documentclass{tufte-book}"
+               ("\\chapter{%s}" . "\\chapter*{%s}")
+               ("\\section{%s}" . "\\section*{%s}")
+               ("\\subsection{%s}" . "\\subsection*{%s}")
+               ("\\subsubsection{%s}" . "\\subsubsection*{%s}")))
+;;;;
+;;
+;; https://github.com/syl20bnr/spacemacs/issues/7055
+;;
+;; Use minted
+(add-to-list 'org-latex-packages-alist '("" "minted"))
+(setq org-latex-listings 'minted)
+(setq org-latex-minted-options '(
+                                 ("frame" "lines")
+                                 ("fontsize" "\\scriptsize")
+                                 ("xleftmargin" "\\parindent")
+                                 ("linenos" "")
+                                 ("breaklines" "")
+                                 ("breakafter" "+")
+                                 ))
+
+(setq org-export-with-smart-quotes t)

--- a/render/render.sh
+++ b/render/render.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+#
+# Make sure there is an argument
+#
+if [ -z $1 ] ; then
+    echo "Usage: $0 path/to/file.txt|.org"
+    exit 1
+fi
+
+#
+# Determine if we are running in Docker or not
+#
+IN_DOCKER=0
+if [ -f /proc/1/cgroup ] ; then
+    docker_lines=`grep docker /proc/1/cgroup | wc -l`
+    if [ $docker_lines > 0 ] ; then
+        IN_DOCKER=1
+    fi
+fi
+BASENAME=`dirname $0`
+EXPORT_ELISP=${BASENAME}/export.el
+EXPORT_CMD='(org-latex-export-to-latex)'
+#
+# If we are running in Docker, set the directory to /source
+#
+if [ $IN_DOCKER -eq 0 ] ; then
+    SOURCE_DIR=`dirname $1`
+else
+    SOURCE_DIR=/source
+    EXPORT_ELISP=/export.el
+fi
+SOURCE_FILE=`basename $1`
+OUTPUT_FILE=${SOURCE_FILE%.*}
+#
+# Set the working directory for where the .txt file is
+#
+cd $SOURCE_DIR
+#
+# use a headless Emacs to convert the org-mode file to a LaTeX file
+#
+echo "Exporting..."
+emacs --batch --no-site-file --load $EXPORT_ELISP --visit $1 --eval $EXPORT_CMD
+#
+# Run the many copies of pdflatex with a makeindex in the middle to resolve all
+# of the references (single-pass compilers ftw!)
+#
+echo "Compiling..."
+pdflatex -shell-escape -halt-on-error $OUTPUT_FILE > /dev/null 2>&1 || exit 1
+pdflatex -shell-escape -halt-on-error $OUTPUT_FILE > /dev/null 2>&1 || exit 1
+pdflatex -shell-escape -halt-on-error $OUTPUT_FILE > /dev/null 2>&1 || exit 1
+echo "Indexing..."
+makeindex $OUTPUT_FILE > /dev/null 2>&1
+echo "Compiling..."
+pdflatex -shell-escape -halt-on-error $OUTPUT_FILE > /dev/null 2>&1 || exit 1
+pdflatex -shell-escape -halt-on-error $OUTPUT_FILE > /dev/null 2>&1 || exit 1
+#
+# delete a bunch of LaTeX output files
+#
+echo "Cleaning up..."
+/bin/rm -r _minted-$OUTPUT_FILE $OUTPUT_FILE.aux $OUTPUT_FILE.idx $OUTPUT_FILE.ilg $OUTPUT_FILE.ind $OUTPUT_FILE.log $OUTPUT_FILE.out $OUTPUT_FILE.toc $OUTPUT_FILE.tex
+echo "Output is in ${OUTPUT_FILE}.pdf"

--- a/sp-rest-api-tutorial.txt
+++ b/sp-rest-api-tutorial.txt
@@ -11,6 +11,7 @@
 #+LATEX_HEADER: \usepackage{xcolor}
 #+LATEX_HEADER: \usepackage{minted}
 #+LATEX_HEADER: \usepackage{makeidx}
+#+LATEX_HEADER: \usepackage{grffile}
 #+LATEX_HEADER: \setcounter{tocdepth}{1}
 #+LATEX_HEADER: \makeindex
 #+LATEX_HEADER: \newsavebox{\titleimage}


### PR DESCRIPTION
- added a directory called `render` that contains a Dockerfile, an Emacs
   configuration file, and a shell script that set up the environment to use
   Emacs and `pdflatex` to render the OrgMode text file to a PDF file
 - added a shell script called `mkpdf.sh` to the top level that, when run,
   finds or builds a Docker image that is then run to render the text file
   to PDF
 - updated the README file to contain notes about this
 - added one LaTeX package to `sp-rest-api-tutorial.txt` so the LaTeX output
   doesn't get confused by image files of the format `name.oldformat.format`