### PR TITLE
Victim IP report; example of nested includes

### DIFF
--- a/code-examples/dest-ip-dos-report.py
+++ b/code-examples/dest-ip-dos-report.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+import json
+import logging
+import requests
+import sys
+from os import environ
+
+
+class DoSHostAlerts:
+    """A class that loads DoS Host Alerts
+
+    It exposes one variable, `victim_ips` that is a json list of victim
+    IPs plus some other alert details
+
+    This is also an example of using the `include` URL parameter and
+    caching data
+
+    What you do with it next is sort of up to you
+    """
+
+    def __init__(self, api_host, token, alerts_to_load=25, perPage=25):
+        self.api_host = api_host
+        self.api_token = token
+        self.per_page = perPage
+        self.alerts_to_load = alerts_to_load
+        self.results = []
+        self.included_cache = {}
+        self.victim_ips = {}
+        self.url = f"https://{self.api_host}/api/sp/alerts/"
+        self.url_params = {
+            "filter": "/data/attributes/alert_type=dos_host_detection",
+            "perPage": self.per_page,
+            "include": "traffic.dest_prefixes",
+        }
+
+    def _get_victim_ips(self):
+        """assemble victim IP data; return a json list
+
+        This uses the cache from the `include` URL parameter to get the
+        related traffic/dest_prefixes information
+        """
+        victim_ips = []
+        for alert in self.results:
+            dest_ip = []
+            # This is the top-level alert information
+            id_ = alert["id"]
+            start = alert["attributes"]["start_time"]
+            if alert["attributes"]["ongoing"]:
+                end = ""
+            else:
+                end = alert["attributes"]["stop_time"]
+
+            # it's just shorted to type `traffic_cache`
+            cache_key = (
+                alert["relationships"]["traffic"]["data"]["type"],
+                alert["relationships"]["traffic"]["data"]["id"],
+            )
+            if cache_key in self.included_cache:
+                traffic_cache = self.included_cache[cache_key]
+                # This traverses the "traffic" relationship to the "dest_prefixes"
+                # relationship and builds a list of destination prefixes (aka
+                # attacked prefixes) out of the cached data that came back from the
+                # one API call with the `include` parameter
+                if "traffic" in alert["relationships"]:
+                    if "dest_prefixes" in traffic_cache["relationships"]:
+                        dest_prefs = traffic_cache["relationships"]["dest_prefixes"]
+                        # I think it's *always* a list, but just in case...
+                        if isinstance(dest_prefs["data"], list):
+                            for dest_pref in dest_prefs["data"]:
+                                key = tuple([dest_pref["type"], dest_pref["id"]])
+                                if key in self.included_cache:
+                                    dest_ip.append(
+                                        self.included_cache[key]["attributes"]["view"][
+                                            "network"
+                                        ]["unit"]["bps"]["name"]
+                                    )
+                        else:
+                            key = tuple(
+                                dest_prefs["data"]["type"], dest_prefs["data"]["id"]
+                            )
+                            if key in self.included_cache:
+                                dest_ip.append(
+                                    self.included_cache[key]["attributes"]["view"][
+                                        "network"
+                                    ]["unit"]["bps"]["name"]
+                                )
+
+            victim_ips.append(
+                {"id": id_, "start": start, "end": end, "dest_ips": dest_ip,}
+            )
+
+        return victim_ips
+
+    def _populate_cache(self, included):
+        """Store the `"included"` block by type/id tuple"""
+        cache = {}
+        for detail in included:
+            if "type" in detail and "id" in detail:
+                type_ = detail["type"]
+                id_ = detail["id"]
+                cache[(type_, id_)] = detail
+
+        return cache
+
+    def load(self):
+        """Load the alerts, populate the cache, find the victim_ips
+
+        This really should just load the alerts and populate the cache,
+        probably, but I don't know how to populate a variable when it is
+        referenced.
+
+        Also, we scrap alerts that are on the last page but beyond the
+        limit set in `alerts_to_load`
+
+        This returns the number of alerts loaded
+        """
+        headers = {"X-Arbux-APIToken": self.api_token}
+        try:
+            self.r = requests.get(self.url, params=self.url_params, headers=headers)
+        except requests.exceptions.ConnectionError as e:
+            log.fatal(f"Connection failed; Attempted URL was: {self.url}")
+            sys.exit(1)
+        self.r = self.r.json()
+        self.results += self.r["data"]
+        if "next" in self.r["links"] and len(self.results) < self.alerts_to_load:
+            logging.debug("loading next page of results")
+            self.url = self.r["links"]["next"]
+            self.url_params = {}
+            self.load()
+
+        self.results = self.results[: self.alerts_to_load]
+
+        self.included_cache.update(self._populate_cache(self.r["included"]))
+
+        self.victim_ips = self._get_victim_ips()
+
+        return len(self.results)
+
+
+if __name__ == "__main__":
+
+    # useful logging levels are:
+    #  - DEBUG :  print debugging information
+    #  - INFO  :  don't print too much
+    #  - WARN  :  only print critical errors and the results
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    SIGHTLINE_HOST = "my-sp-leader.example.com"
+    NUMBER_OF_ALERTS = 15
+    ALERTS_PER_PAGE = 10
+    logging.debug(
+        f"Loading {NUMBER_OF_ALERTS} alerts {ALERTS_PER_PAGE} alerts at a time."
+    )
+    if "SIGHTLINE_HOST" in environ:
+        SIGHTLINE_HOST = environ["SIGHTLINE_HOST"]
+    if "API_TOKEN" in environ:
+        API_TOKEN = environ["API_TOKEN"]
+    else:
+        logging.fatal(
+            'Please set the environment variable "API_TOKEN" to your SP REST API Token'
+        )
+        sys.exit(1)
+
+    dos_host_alerts = DoSHostAlerts(
+        SIGHTLINE_HOST, API_TOKEN, NUMBER_OF_ALERTS, ALERTS_PER_PAGE
+    )
+    num_alerts = dos_host_alerts.load()
+    logging.info(f"Loaded {num_alerts} alerts")
+    logging.info("Victim IPs:")
+    print("{}".format(json.dumps(dos_host_alerts.victim_ips, indent=4)))

--- a/sp-rest-api-tutorial.txt
+++ b/sp-rest-api-tutorial.txt
@@ -1573,7 +1573,6 @@ listings package.
 
    #+INCLUDE: code-examples/mit-filter-by-alert.py src python
 
-
 ** Example: Differences in output between accounts with different authorization
    #+INDEX: /alerts/ endpoint
    #+INDEX: authorization
@@ -2249,6 +2248,75 @@ listings package.
     unnecessarily nested or complicated when taken out of context,
     however, this structure allows for simple construction of the
     entirety of the alert data into one JSON object.
+
+** Example: A List of Victim IPs and using the =include= functionality
+   #+INDEX: /alerts/ endpoint
+   #+INDEX: /alerts/ endpoint!sub-objects
+   #+INDEX: cache
+   #+INDEX: caching
+   #+INDEX: include
+
+   It can be useful for an enterprise or ISP to see what IP addresses
+   on their network are often attacked, and getting a list of the
+   victim IP addresses from the SP alerts list can help to start
+   answering this question.
+
+   The following example program demonstrates how to use the
+   ~?include=~ URL parameter in an API request, store the data in the
+   ="included":= block of the response, and refer to that in other
+   places.  The key thing to recognize is that the ="included":= block
+   is a flat list of objects that is identified by the type/ID pair
+   and that the type/ID pair is also in the relationships in the
+   ="data":= block of the response.
+
+   In this particular example, the ~?include=~ parameter also includes
+   subobjects by asking for =traffic.dest_prefixes=; that is, the
+   request to include both the data from the =traffic= relationship
+   and the data from the =dest_prefixes= relationship that is in
+   =traffic=.
+
+   #+INCLUDE: code-examples/dest-ip-dos-report.py src python
+
+   The output from this example is not very pretty, and doesn't
+   include any analysis of the victim IP frequency, alert levels, or
+   anything else.  A minimized version of the output looks like:
+
+   #+BEGIN_SRC json
+     [
+         {
+             "id": "1469814",
+             "start": "2020-01-17T18:46:25+00:00",
+             "end": "2020-01-17T19:04:59+00:00",
+             "dest_ips": []
+         },
+         {
+             "id": "1469808",
+             "start": "2020-01-17T18:31:45+00:00",
+             "end": "2020-01-17T18:56:00+00:00",
+             "dest_ips": [
+                 "3ffe:1:14:20::1/128"
+             ]
+         },
+         {
+             "id": "1469807",
+             "start": "2020-01-17T18:31:45+00:00",
+             "end": "2020-01-17T18:55:00+00:00",
+             "dest_ips": [
+                 "3ffe:1:14:20::/128"
+             ]
+         },
+         {
+             "id": "1469804",
+             "start": "2020-01-17T18:24:45+00:00",
+             "end": "2020-01-17T18:40:59+00:00",
+             "dest_ips": [
+                 "85.94.160.137/32"
+             ]
+         }
+     ]
+   #+END_SRC
+
+   This program can take several seconds to complete.
 
 * Configuration
 


### PR DESCRIPTION
This is an example of using nested includes in Python; it gets
traffic.dest_prefixes, stores that in a cache, then refers to the cache from
the relationships in the alerts data.